### PR TITLE
save last url entered to local storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
       },
       "devDependencies": {
         "@ava/typescript": "^5.0.0",
-        "@eslint/js": "^8.57.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@sindresorhus/tsconfig": "^5.0.0",
         "@types/bootstrap": "^5.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@ava/typescript": "^5.0.0",
+        "@eslint/js": "^8.57.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@sindresorhus/tsconfig": "^5.0.0",
         "@types/bootstrap": "^5.2.10",

--- a/src/app.ts
+++ b/src/app.ts
@@ -409,10 +409,10 @@ window.onload = (_) => {
     );
   }
 
-  $("#modalSettingsModel").on('shown.bs.modal', function (_) {
+  $('#modalSettingsModel').on('shown.bs.modal', function (_) {
     const url = localStorage.getItem('apiUrl');
     if (url) {
-      $("#modelurl").val(url);
+      $('#modelurl').val(url);
     }
-  })
+  });
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -209,6 +209,7 @@ export class App {
         this.models.custom.selected = true;
         const inputBox = $('#modelurl');
         const url = String(inputBox.val());
+
         WebServiceModel.verifyUrl(url).then((error) => {
           const errorText = $('#urlErrorText');
           if (error === null) {
@@ -218,6 +219,7 @@ export class App {
             const saveElement = $('#saveNotification')[0];
             const toast = bootstrap.Toast.getOrCreateInstance(saveElement);
             toast.show();
+            localStorage.setItem('apiUrl', url);
             const notificationText = $('#saveNotificationText');
             notificationText.text('Webservice url saved!');
             setTimeout(() => {
@@ -406,4 +408,11 @@ window.onload = (_) => {
         'Please consider using a different browser.',
     );
   }
+
+  $("#modalSettingsModel").on('shown.bs.modal', function (_) {
+    const url = localStorage.getItem('apiUrl');
+    if (url) {
+      $("#modelurl").val(url);
+    }
+  })
 };


### PR DESCRIPTION
Fixes #9 

The entered URL is stored locally in the client. Uses the `localStorage` API from any browser