### PR TITLE
Only provide a central point

### DIFF
--- a/doc/remote_api.yaml
+++ b/doc/remote_api.yaml
@@ -36,8 +36,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Point'
-              maxLength: 478
-              minLength: 478
+              maxLength: 472
+              minLength: 472
         sha256:
           type: string
           format: sha256

--- a/src/graph/face_landmarks_features.ts
+++ b/src/graph/face_landmarks_features.ts
@@ -80,6 +80,23 @@ export const FACE_FEATURE_LIPS = Array.from(
 );
 
 /**
+ * We don't use the exact implementation of mediapipe. we calculate the center point
+ * and ignore the rest. The "UPDATED" arrays contain the center point. The array in FaceLandmarker
+ * remain untouched
+ */
+export const UPDATED_LEFT_IRIS = [
+  FaceLandmarker.FACE_LANDMARKS_LEFT_IRIS[0],
+] as Connection[];
+// 474
+export const UPDATED_RIGHT_IRIS = [
+  FaceLandmarker.FACE_LANDMARKS_RIGHT_IRIS[0],
+] as Connection[];
+// 469
+
+UPDATED_LEFT_IRIS[0].end = UPDATED_LEFT_IRIS[0].start;
+UPDATED_RIGHT_IRIS[0].end = UPDATED_RIGHT_IRIS[0].start;
+
+/**
  * Array of unique face feature point IDs related to the left eye.
  */
 export const FACE_FEATURE_LEFT_EYE = Array.from(
@@ -87,8 +104,8 @@ export const FACE_FEATURE_LEFT_EYE = Array.from(
     FaceLandmarker.FACE_LANDMARKS_LEFT_EYE.map((con) => con.start)
       .concat(FaceLandmarker.FACE_LANDMARKS_LEFT_EYE.map((con) => con.end))
       .concat(
-        FaceLandmarker.FACE_LANDMARKS_LEFT_IRIS.map((con) => con.start).concat(
-          FaceLandmarker.FACE_LANDMARKS_LEFT_IRIS.map((con) => con.end),
+        UPDATED_LEFT_IRIS.map((con) => con.start).concat(
+          UPDATED_LEFT_IRIS.map((con) => con.end),
         ),
       ),
   ),
@@ -113,8 +130,8 @@ export const FACE_FEATURE_RIGHT_EYE = Array.from(
     FaceLandmarker.FACE_LANDMARKS_RIGHT_EYE.map((con) => con.start)
       .concat(FaceLandmarker.FACE_LANDMARKS_RIGHT_EYE.map((con) => con.end))
       .concat(
-        FaceLandmarker.FACE_LANDMARKS_RIGHT_IRIS.map((con) => con.start).concat(
-          FaceLandmarker.FACE_LANDMARKS_RIGHT_IRIS.map((con) => con.end),
+        UPDATED_RIGHT_IRIS.map((con) => con.start).concat(
+          UPDATED_RIGHT_IRIS.map((con) => con.end),
         ),
       ),
   ),

--- a/src/model/mediapipe.ts
+++ b/src/model/mediapipe.ts
@@ -1,6 +1,10 @@
 import { ModelApi } from './modelApi';
 import { Graph } from '../graph/graph';
-import { findNeighbourPointIds } from '../graph/face_landmarks_features';
+import {
+  findNeighbourPointIds,
+  UPDATED_LEFT_IRIS,
+  UPDATED_RIGHT_IRIS,
+} from '../graph/face_landmarks_features';
 import { FaceLandmarker, FilesetResolver } from '@mediapipe/tasks-vision';
 import { Point2D } from '../graph/point2d';
 import { Point3D } from '../graph/point3d';
@@ -46,6 +50,43 @@ export class MediapipeModel implements ModelApi<Point2D> {
             .map((landmarks) =>
               landmarks
                 .map((dict, idx) => {
+                  // calculate the iris center
+                  if (idx === UPDATED_LEFT_IRIS[0].start) {
+                    const iris = FaceLandmarker.FACE_LANDMARKS_LEFT_IRIS.reduce(
+                      (acc, con) => {
+                        acc.x += landmarks[con.start].x;
+                        acc.y += landmarks[con.start].y;
+                        acc.z += landmarks[con.start].z;
+                        return acc;
+                      },
+                      { x: 0.0, y: 0.0, z: 0.0 },
+                    );
+
+                    const avgFactor =
+                      FaceLandmarker.FACE_LANDMARKS_LEFT_IRIS.length;
+                    dict.x = iris.x / avgFactor;
+                    dict.y = iris.y / avgFactor;
+                    dict.z = iris.z / avgFactor;
+                  }
+                  if (idx === UPDATED_RIGHT_IRIS[0].start) {
+                    const iris =
+                      FaceLandmarker.FACE_LANDMARKS_RIGHT_IRIS.reduce(
+                        (acc, con) => {
+                          acc.x += landmarks[con.start].x;
+                          acc.y += landmarks[con.start].y;
+                          acc.z += landmarks[con.start].z;
+                          return acc;
+                        },
+                        { x: 0.0, y: 0.0, z: 0.0 },
+                      );
+
+                    const avgFactor =
+                      FaceLandmarker.FACE_LANDMARKS_RIGHT_IRIS.length;
+                    dict.x = iris.x / avgFactor;
+                    dict.y = iris.y / avgFactor;
+                    dict.z = iris.z / avgFactor;
+                  }
+
                   const ids = Array.from(
                     findNeighbourPointIds(
                       idx,
@@ -57,7 +98,19 @@ export class MediapipeModel implements ModelApi<Point2D> {
                 })
                 .map((point) => point as Point2D),
             )
-            .map((landmarks) => new Graph(landmarks));
+            .map((landmarks) => {
+              landmarks = landmarks.filter((point) => {
+                return ![
+                  ...FaceLandmarker.FACE_LANDMARKS_LEFT_IRIS.slice(1).map(
+                    (con) => con.start,
+                  ),
+                  ...FaceLandmarker.FACE_LANDMARKS_RIGHT_IRIS.slice(1).map(
+                    (con) => con.start,
+                  ),
+                ].includes(point.id);
+              });
+              return new Graph(landmarks);
+            });
           if (graphs) {
             resolve(graphs[0]);
           }

--- a/src/model/webservice.ts
+++ b/src/model/webservice.ts
@@ -53,7 +53,7 @@ export class WebServiceModel implements ModelApi<Point2D> {
           if (!json['points']) {
             throw new Error("The request didn't return any point data.");
           }
-          return json['points'];
+          return json['points'][0];
         })
         .then((landmarks) =>
           landmarks.map((dict: { x: number; y: number }, idx: number) => {


### PR DESCRIPTION
- [x] Central Point of iris is now calculated from media pipe annotation
- [x] updated api documentation
- [x] Fixes a bug where the annotation from the API wasn't read properly

## Todo:
- [ ] The point keeps the index of the original first point. This results in an index that is larger than the length of the array containing the points.