### PR TITLE
Fix image in center after selection

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -66,6 +66,7 @@ export class App {
       } else {
         this.editor.graph = this.getSelectedFileHistory()?.get();
       }
+      this.editor.center();
     });
   }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
BugFix

- **What is the current behavior?** (You can also link to an open issue here)
After selecting an image from the thumbnail gallery, the newly selected photo will be displayed with the previous zoom and offset factors; accordingly, the image location may be off and may not fit the screen.

- **What is the new behavior (if this is a feature change)?**
After selecting an image from the thumbnail gallery, the zoom and offset factors will be reset to their default values.
