### PR TITLE
Fix line endings on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
When checking out the code on default settings on windows this will lead to files with CRLF line breaks. this is marked as an error with the linter.

This PR specifies that the line ends are only LF